### PR TITLE
Misc updates to `runtime_env` doc

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -427,11 +427,6 @@ To get information about the current available resource capacity of your cluster
 
 Runtime Environments
 -----------------------------------
-
-.. note::
-
-    This API is in beta and may change before becoming stable.
-
 .. note::
 
     This feature requires a full installation of Ray using ``pip install "ray[default]"``.
@@ -441,7 +436,7 @@ On Mac OS and Linux, Ray 1.4+ supports dynamically setting the runtime environme
 The ``runtime_env`` is a (JSON-serializable) dictionary that can be passed as an option to tasks and actors, and can also be passed to ``ray.init()``.
 The runtime environment defines the dependencies required for your workload.
 
-You can specify a runtime environment for your whole job using ``ray.init()`` or Ray Client...
+You can specify a runtime environment for your whole job using ``ray.init()``
 
 .. literalinclude:: ../examples/doc_code/runtime_env_example.py
    :language: python


### PR DESCRIPTION
1. I think the feature GA'ed in 1.6
2. Per Ray client documentation, `ray.init` is indeed the way to use Ray client

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
